### PR TITLE
Add basic two's complement addition and subtraction to binary.dart

### DIFF
--- a/arm7_tdmi/lib/src/instruction/arithmetic.dart
+++ b/arm7_tdmi/lib/src/instruction/arithmetic.dart
@@ -1,0 +1,33 @@
+import 'package:arm7_tdmi/arm7_tdmi.dart';
+import 'package:arm7_tdmi/src/utils/bits.dart';
+import 'package:binary/binary.dart';
+
+void add(
+    {Arm7TdmiOperatingMode mode,
+    Arm7TdmiRegisters gprs,
+    Arm7TdmiCondition condition,
+    int rd,
+    int rn,
+    int shifterOperand,
+    bool updatesSpsr}) {
+  if (condition.passes(gprs.cpsr)) {
+    final op1 = gprs.get(rn);
+    final trueResult = uint32.add(op1, shifterOperand);
+    gprs.set(rd, trueResult);
+
+    if (updatesSpsr && rd == 15) {
+      if (mode.canAccessSpsr) {
+        // set cpsr to spsr.
+        throw new UnimplementedError();
+      } else {
+        // unpredictable
+        throw new UnimplementedError();
+      }
+    } else {
+      gprs.cpsr.n = sign(trueResult) == 1;
+      gprs.cpsr.z = rd == 0;
+      gprs.cpsr.c = carryFrom(trueResult) == 1;
+      gprs.cpsr.v = overflowFromAdd(op1, shifterOperand, trueResult) == 1;
+    }
+  }
+}

--- a/arm7_tdmi/lib/src/utils/bits.dart
+++ b/arm7_tdmi/lib/src/utils/bits.dart
@@ -2,10 +2,10 @@
 ///
 /// Every function in this library treats 32-bit strings as little-endian:
 /// leftmost bit is 31, rightmost bit is 0.
-import 'dart:math';
+import 'package:binary/binary.dart';
 
-const maxSignedInt32 = 0x7FFFFFFF;
-const minSignedInt32 = -maxSignedInt32;
+final maxSignedInt32 = int32.max;
+final minSignedInt32 = int32.min;
 
 /// Whether [bit] is set to 1
 bool isSet(int bit) => bit == 1;
@@ -47,17 +47,16 @@ int getBitChunk(int leftBit, int size, int bits) {
 int getBitRange(int left, int right, int bits) =>
     getBitChunk(left, left - right + 1, bits);
 
-/// Returns 1 iff [op1] + [op2] + [op3] is greater than 2^16 - 1,
-/// else 0.
-int carryFrom(int op1, int op2, [int op3 = 0]) =>
-    op1 + op2 + op3 > pow(2, 16) - 1 ? 1 : 0;
+/// Returns 1 iff [op1] + [op2] + [op3] is greater than [int32.max], else 0.
+int carryFrom(int result) => result > int32.max ? 1 : 0;
 
 /// Returns 0 if [number] is non-negative, else 1.
 int sign(int number) => getBit(31, number);
 
 /// Returns 1 iff [op1] + [op2] + [op3] produces an integer overflow, else 0.
-int overflowFromAdd(int op1, int op2, [int op3 = 0]) =>
-    op1 + op2 + op3 > maxSignedInt32 ? 1 : 0;
+int overflowFromAdd(int op1, int op2, int result) =>
+    sign(op1) == sign(op2) && sign(result) != sign(op1) ? 1 : 0;
 
 /// Returns 1 iff [op1] - [op2] produces a 32-bit signed overflow, else 0.
-int overflowFromSub(int op1, int op2) => op1 - op2 < minSignedInt32 ? 1 : 0;
+int overflowFromSub(int op1, int op2, int result) =>
+    sign(op1) != sign(op2) && sign(result) != sign(op1) ? 1 : 0;

--- a/arm7_tdmi/pubspec.yaml
+++ b/arm7_tdmi/pubspec.yaml
@@ -13,6 +13,8 @@ environment:
 dependencies:
   func: '^0.1.1'
   quiver: '^0.24.0'
+  binary:
+    path: ../binary
 
 dev_dependencies:
   test: '^0.12.18+1'

--- a/arm7_tdmi/test/utils/bits_test.dart
+++ b/arm7_tdmi/test/utils/bits_test.dart
@@ -63,28 +63,30 @@ void main() {
 
     test('carryFrom should return 1 iff the given operands produce a carry',
         () {
-      expect(carryFrom(maxSignedInt32, maxSignedInt32), 1);
-      expect(carryFrom(pow(2, 15), pow(2, 15)), 1);
-      expect(carryFrom(pow(2, 15), pow(2, 15) - 1), 0);
-      expect(carryFrom(1, 0), 0);
-      expect(carryFrom(0, 0), 0);
+      expect(carryFrom(maxSignedInt32 + maxSignedInt32), 1);
+      expect(carryFrom(pow(2, 15) + pow(2, 15)), 0);
+      expect(carryFrom(pow(2, 15) + pow(2, 15) - 1), 0);
+      expect(carryFrom(1), 0);
+      expect(carryFrom(0), 0);
     });
 
     test('overflowFromAdd should return 1 iff an addition produces an overflow',
         () {
-      expect(overflowFromAdd(maxSignedInt32, 0), 0);
-      expect(overflowFromAdd(maxSignedInt32, 1), 1);
-      expect(overflowFromAdd(maxSignedInt32 ~/ 2, maxSignedInt32), 1);
-      expect(overflowFromAdd(1, 2), 0);
+      expect(overflowFromAdd(1, 2, 3), 0);
+      expect(overflowFromAdd(-1, 2, 1), 0);
+      expect(overflowFromAdd(maxSignedInt32, 0, maxSignedInt32), 0);
+      expect(overflowFromAdd(maxSignedInt32, 1, maxSignedInt32 + 1), 1);
+      expect(overflowFromAdd(maxSignedInt32, 10, maxSignedInt32 + 10), 1);
     });
 
     test(
         'overflowFromSub should return 1 iff a subtraction produces an '
         'overflow', () {
-      expect(overflowFromSub(minSignedInt32, 0), 0);
-      expect(overflowFromSub(minSignedInt32, 1), 1);
-      expect(overflowFromSub(minSignedInt32 ~/ 2, maxSignedInt32), 1);
-      expect(overflowFromSub(1, 2), 0);
+      expect(overflowFromSub(1, 2, 3), 0);
+      expect(overflowFromSub(-1, 2, 1), 1);
+      expect(overflowFromSub(minSignedInt32, 0, minSignedInt32), 0);
+      expect(overflowFromSub(minSignedInt32, 1, minSignedInt32 - 1), 1);
+      expect(overflowFromSub(minSignedInt32, 10, maxSignedInt32 - 10), 1);
     });
   });
 }

--- a/binary/lib/binary.dart
+++ b/binary/lib/binary.dart
@@ -150,6 +150,23 @@ class Integral implements Comparable<Integral> {
     return bitRange(bits, left, right);
   }
 
+  /// Returns an int containing only bits [0, [length]) from [bits].
+  int mask(int bits) => bits & ~(~0 << length);
+
+  /// Returns the true (unmasked) result of [a] + [b].
+  int add(int a, int b) {
+    int trueResult = mask(a) + mask(b);
+    if (isSigned) {
+      var isNegative = getBit(length - 1, trueResult) == 1;
+      // If signed and result is negative. Return -1 * reverse two's-compliment.
+      return isNegative ? -1 * ~(trueResult - 1) : trueResult;
+    }
+    return trueResult;
+  }
+
+  /// Returns the true (unmasked) result of [a] - [b].
+  int subtract(int a, int b) => isSigned ? add(a, (~b) + 1) : mask(a) - mask(b);
+
   @override
   int compareTo(Integral other) => length.compareTo(other.length);
 

--- a/binary/test/binary_test.dart
+++ b/binary/test/binary_test.dart
@@ -36,6 +36,32 @@ void main() {
       expect(uint32.inRange(pow(2, 32)), isFalse);
     });
 
+    test('mask should correctly mask values', () {
+      int maxTimes16 = uint32.max << 4;
+      expect(uint32.mask(maxTimes16), 0xFFFFFFF0);
+    });
+
+    test('add should correctly add values', () {
+      expect(uint32.add(0, 0), 0);
+      expect(uint32.add(10, 20), 30);
+      expect(uint32.add(uint32.max, 1), 0x100000000);
+    });
+
+    test('subtract should correctly subtract values', () {
+      // Positive operands.
+      expect(uint32.subtract(0, 0), 0);
+      // 20 - 10 = 10
+      expect(uint32.subtract(20, 10), 0xA);
+
+      // One negative operand
+      // 10 - -10 = 0xA - 0xFFFFFFF6 = 10 - (2^32 - 10)
+      expect(uint32.subtract(10, -10), 10 - (pow(2, 32) - 10));
+
+      // Two negative operands
+      // -10 - -10 = 0xFFFFFFF6 - 0xFFFFFFF6 = (2^32 - 10) - (2^32 - 10) = 0
+      expect(uint32.subtract(-10, -10), 0);
+    });
+
     test('should be able to iterate through bits', () {
       expect(
         uint32.toIterable(2),
@@ -44,6 +70,48 @@ void main() {
           1,
         ]..addAll(new Iterable.generate(30, (_) => 0)),
       );
+    });
+  });
+
+  group('int32', () {
+    test('mask should correctly mask values', () {
+      int maxTimes16 = int32.max << 4;
+      expect(int32.mask(maxTimes16), 0xFFFFFFF0);
+    });
+
+    test('add should correctly add values', () {
+      // Positive operands
+      expect(int32.add(0, 0), 0);
+      expect(int32.add(10, 20), 30);
+      expect(int32.add(int32.max, 1), 0x80000000);
+
+      // One negative operand
+      // -2 + 3 == 1 with carry bit
+      expect(int32.add(-2, 3), 0x100000001);
+      // -2 + 1 == -1
+      expect(int32.add(-2, 1), 0xFFFFFFFF);
+
+      // Two negative operands
+      // -1 + -1 == -2 with carry bit
+      expect(int32.add(-1, -1), 0x1FFFFFFFE);
+    });
+
+    test('subtract should correctly subtract values', () {
+      // Positive operands.
+      expect(int32.subtract(0, 0), 0);
+      // 20 - 10 = 20 + -10 = 0x14 + 0xFFFFFFF6 = 10 with carry bit
+      expect(int32.subtract(20, 10), 0x010000000A);
+
+      // One negative operand
+      // 10 - -10 = 10 + 10 = 0xA - 0xA = 20
+      expect(int32.subtract(10, -10), 0x14);
+
+      // -10 - 10 = 0xFFFFFFF6 - 0xA = -20 with carry bit
+      expect(int32.subtract(-10, 10), 0x1FFFFFFEC);
+
+      // Two negative operands
+      // -10 - -10 = -10 + 10 = 0xFFFFFFF6 + 0xA = 0 with carry bit
+      expect(int32.subtract(-10, -10), 0x100000000);
     });
   });
 


### PR DESCRIPTION
- Add example usage in arithmetic.dart with add instruction.
- Fix incorrect carryFrom and overflow implementations: true values shouldn't be recomputed.