### PR TITLE
Add back tests for Arm7TdmiCondition.

### DIFF
--- a/arm7_tdmi/lib/src/cpu/psr.dart
+++ b/arm7_tdmi/lib/src/cpu/psr.dart
@@ -183,7 +183,7 @@ class Arm7TdmiPsr {
   bool _isSet(int index) => _readBit(index) == 1;
 
   // Returns a bit by index.
-  int _readBit(int index) => int32.get(_read(), index);
+  int _readBit(int index) => uint32.get(_read(), index);
 
   // Toggles the value of a bit.
   void _toggleBit(int index, bool value) {
@@ -192,12 +192,12 @@ class Arm7TdmiPsr {
 
   // Sets a bit by index.
   void _setBit(int index) {
-    _write(int32.set(_read(), index));
+    _write(uint32.set(_read(), index));
   }
 
   // Un-sets a bit by index.
   void _unsetBit(int index) {
-    _write(int32.clear(_read(), index));
+    _write(uint32.clear(_read(), index));
   }
 
   /// Returns the bits representing this PSR.

--- a/arm7_tdmi/test/condition/arm_condition_test.dart
+++ b/arm7_tdmi/test/condition/arm_condition_test.dart
@@ -60,5 +60,177 @@ main() {
     ],
   );
 
+  check(
+    Arm7TdmiCondition.CS,
+    success: [
+      cpsr(c: 1),
+    ],
+    failure: [
+      cpsr(c: 0),
+    ],
+  );
+
+  check(
+    Arm7TdmiCondition.CC,
+    success: [
+      cpsr(c: 0),
+    ],
+    failure: [
+      cpsr(c: 1),
+    ],
+  );
+
+  check(
+    Arm7TdmiCondition.MI,
+    success: [
+      cpsr(n: 1),
+    ],
+    failure: [
+      cpsr(n: 0),
+    ],
+  );
+
+  check(
+    Arm7TdmiCondition.PL,
+    success: [
+      cpsr(n: 0),
+    ],
+    failure: [
+      cpsr(n: 1),
+    ],
+  );
+
+  check(
+    Arm7TdmiCondition.VS,
+    success: [
+      cpsr(v: 1),
+    ],
+    failure: [
+      cpsr(v: 0),
+    ],
+  );
+
+  check(
+    Arm7TdmiCondition.VC,
+    success: [
+      cpsr(v: 0),
+    ],
+    failure: [
+      cpsr(v: 1),
+    ],
+  );
+
+  check(
+    Arm7TdmiCondition.HI,
+    success: [
+      cpsr(c: 1, n: 0),
+    ],
+    failure: [
+      cpsr(c: 1, n: 1),
+      cpsr(c: 0, n: 0),
+    ],
+  );
+
+  check(
+    Arm7TdmiCondition.LS,
+    success: [
+      cpsr(c: 0, n: 0),
+      cpsr(c: 1, n: 1),
+    ],
+    failure: [
+      cpsr(c: 1, n: 0),
+    ],
+  );
+
+  check(
+    Arm7TdmiCondition.GE,
+    success: [
+      cpsr(v: 0, n: 0),
+      cpsr(v: 1, n: 1),
+    ],
+    failure: [
+      cpsr(v: 1, n: 0),
+      cpsr(v: 0, n: 1),
+    ],
+  );
+
+  check(
+    Arm7TdmiCondition.LT,
+    success: [
+      cpsr(v: 1, n: 0),
+      cpsr(v: 0, n: 1),
+    ],
+    failure: [
+      cpsr(v: 0, n: 0),
+      cpsr(v: 1, n: 1),
+    ],
+  );
+
+  check(
+    Arm7TdmiCondition.GT,
+    success: [
+      cpsr(z: 0, v: 0, n: 0),
+      cpsr(z: 0, v: 1, n: 1),
+    ],
+    failure: [
+      cpsr(z: 1, v: 0, n: 0),
+      cpsr(z: 1, v: 1, n: 1),
+      cpsr(z: 0, v: 0, n: 1),
+      cpsr(z: 0, v: 1, n: 0),
+    ],
+  );
+
+  check(
+    Arm7TdmiCondition.LE,
+    success: [
+      cpsr(z: 1, v: 0, n: 0),
+      cpsr(z: 1, v: 1, n: 1),
+      cpsr(z: 0, v: 0, n: 1),
+      cpsr(z: 0, v: 1, n: 0),
+    ],
+    failure: [
+      cpsr(z: 0, v: 0, n: 0),
+      cpsr(z: 0, v: 1, n: 1),
+    ],
+  );
+
+  check(
+    Arm7TdmiCondition.AL,
+    success: [
+      cpsr(v: 1, c: 1, z: 1, n: 1),
+      cpsr(v: 0, c: 1, z: 1, n: 1),
+      cpsr(v: 1, c: 0, z: 1, n: 1),
+      cpsr(v: 1, c: 1, z: 0, n: 1),
+      cpsr(v: 1, c: 1, z: 1, n: 0),
+      cpsr(v: 0, c: 0, z: 1, n: 1),
+      cpsr(v: 1, c: 1, z: 0, n: 0),
+      cpsr(v: 1, c: 0, z: 0, n: 0),
+      cpsr(v: 0, c: 1, z: 0, n: 0),
+      cpsr(v: 0, c: 0, z: 1, n: 0),
+      cpsr(v: 0, c: 0, z: 0, n: 1),
+      cpsr(v: 0, c: 0, z: 0, n: 0),
+    ],
+    failure: [],
+  );
+
+  check(
+    Arm7TdmiCondition.NV,
+    success: [],
+    failure: [
+      cpsr(v: 1, c: 1, z: 1, n: 1),
+      cpsr(v: 0, c: 1, z: 1, n: 1),
+      cpsr(v: 1, c: 0, z: 1, n: 1),
+      cpsr(v: 1, c: 1, z: 0, n: 1),
+      cpsr(v: 1, c: 1, z: 1, n: 0),
+      cpsr(v: 0, c: 0, z: 1, n: 1),
+      cpsr(v: 1, c: 1, z: 0, n: 0),
+      cpsr(v: 1, c: 0, z: 0, n: 0),
+      cpsr(v: 0, c: 1, z: 0, n: 0),
+      cpsr(v: 0, c: 0, z: 1, n: 0),
+      cpsr(v: 0, c: 0, z: 0, n: 1),
+      cpsr(v: 0, c: 0, z: 0, n: 0),
+    ],
+  );
+
   // TODO: Add remaining test cases back for CS -> NV.
 }


### PR DESCRIPTION
Closes https://github.com/matanlurey/gba.dart/issues/23

Also fixed a bug in the _PSR_, ~~`int32`~~ -> `uint32`